### PR TITLE
Fix typos and links, Fixes #1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Focus Contributing Guide
 
-To submit a Focus you can either open an Issue, for whcih there will be a set of boxes to fill out, or you can submit a Pull Request. If you are submitting a Pull Request then please look at the [focus folder](https://github.com/PrivacyDingus/focus-templates/blob/main/focus) which contains ```.focus``` file formats as a reference guide.
+To submit a Focus you can either open an Issue, for which there will be a set of boxes to fill out, or you can submit a Pull Request. If you are submitting a Pull Request then please look at the [focus folder](./focus) which contains ```.focus``` file formats as a reference guide.
 
 ### The following items will be required in order to submit a Focus:
 - a suggested name for the Focus, we will not be able to use the same name twice
@@ -22,11 +22,11 @@ In order to be a candidate for the global Mojeek Focus Template Library, a Focus
 ## Creating a Focus
 Before submitting a Focus, you'll need to create one, and make sure that it does what you want it to do. To do this you'll need to visit your [Focus Dashboard](https://www.mojeek.com/focus/dashboard) and click the *Create new* button.
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/focus_dashboard.png">
+<img src="./assets/focus_dashboard.png">
 
 You will then be asked to name your Focus, please choose something that is clear, descriptive, and that relates to the purpose that your Focus will have. You can go back and edit this at any time, so if your idea is not quite *there* yet, you can give it a placeholder name. Just remember to edit this before submitting. 
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/focus_name.png">
+<img src="./assets/focus_name.png">
 
 In the *Sites to Search* box you enter in all the sites the Focus is intended to search across, one per line up to a limit of 25 in the *Dashboard*. 
 
@@ -34,11 +34,11 @@ You can add any of the following:
 Subdomain: ```www.example.com```
 Domain: ```.example.com```
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/sites_to_search.png">
+<img src="./assets/sites_to_search.png">
 
 In the *Exceptions* box you put sites which the Focus should exclude. This step mainly exists to allow you to exclude subdomains from a Focus, so if you have ```.example.com``` included, but you want to not search across pages from ```developers.example.com``` then this subdomain would go in this box. 
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/exceptions.png">
+<img src="./assets/exceptions.png">
 
 Once you're happy with your Focus, press *Save* to return to the Dashboard.
 
@@ -48,11 +48,11 @@ In order to check the utility and functionality of your newly-created Focus, we'
 ## Submitting a Focus
 Once created a Focus lives in your Dashboard; by clicking near the Focus' Name you can expand its box.
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/completed_focus.png">
+<img src="./assets/completed_focus.png">
 
 You then click the button labelled *Backup this Focus*; this tool can also be used to backup your creations if you use other browsers, or regularly clear cookies. 
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/backup.png">
+<img src="./assets/backup.png">
 
 Your created Focus contains most of the information needed for submitting it here between ```{``` and ```}```   
 
@@ -60,9 +60,9 @@ Your created Focus contains most of the information needed for submitting it her
 - The items after ```i=``` are your inclusions
 - The items after ```&e=``` are your exclusions (if you have none then this will not be featured)
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/backup_highlighted.png">
+<img src="./assets/backup_highlighted.png">
 
-This text can now be used to raise an Issue to submit your Focus, you can find the currently-available templates in the [focus folder](https://github.com/PrivacyDingus/focus-templates/blob/main/focus), here is an example:
+This text can now be used to raise an Issue to submit your Focus, you can find the currently-available templates in the [focus folder](./focus), here is an example:
   
 ```# title: Dictionary```  
 ```# description: Dictionary search```  
@@ -80,16 +80,16 @@ This text can now be used to raise an Issue to submit your Focus, you can find t
 ## Icons
 A Focus Template will display like the ones below, and so your submission is easier to add if it has an icon with it. 
 
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/default_templates.png">
+<img src="./assets/default_templates.png">
 
 These icons are best as single-colour 16x16 svg files, if this is not possible then please get in touch via our [Contact Page](https://www.mojeek.com/about/contact), [Community](https://community.mojeek.com/) or flag this in your Issue. You can also use websites like [svgrepo](https://www.svgrepo.com/) to find commercial-friendly and royalty free icons, use the *monochrome* search option to take out icons which might display badly when added to the templates. 
 
-If the Focus you're creating would suit an icon that is already in this repo, then grab the name of it from the [icons folder](https://github.com/PrivacyDingus/focus-templates/blob/main/icons) and use that when you submit your issue.
+If the Focus you're creating would suit an icon that is already in this repo, then grab the name of it from the [icons folder](./icons) and use that when you submit your issue.
 
 ## Editing a Focus
 Through using a template you might find a way that it could be improved, through a better description and title, or through adding in more inclusions or exclusions. For example, if your usage of a template consistently returned an irrelevant subdomain, then you might want to help out by proposing a change which excludes this. 
 
 **If you are doing this through an Issue** please use the Issue template for editing a Focus.  
-**If you are doing this through a Pull Request** please directly edit the ```.focus``` file in the [focus folder](https://github.com/PrivacyDingus/focus-templates/blob/main/focus).
+**If you are doing this through a Pull Request** please directly edit the ```.focus``` file in the [focus folder](./focus).
 
 As with submissions, not all edits will be actioned when it comes to templates. Please be clear in your reasoning as to why the change would improve the user experience of the Focus in question. 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,7 @@
 # FAQ
 
-**What is Focus for?**
+**What is Focus for?**  
+
 Focus allows you to build your own search tools using a genuine web index. It’s an update of something that we previously called Personal Search, [first released in 2006](https://web.archive.org/web/20060220233451/http://www.mojeek.com/mps). 
 
 From the easy-to-use interface you can:
@@ -13,9 +14,12 @@ From the easy-to-use interface you can:
 - share your Mojeek Focus creations with others.
 - use and edit a set of templates provided by both the Mojeek team and other users through this repo.
 
-**How do I submit without a Github account?** Github and other similar developer platforms can be very useful for this kind of collaborative work, but we understand that they are not for everyone. If you've created something you really think would be better of shared with others, please get in contact via the [contact page](https://www.mojeek.com/about/contact) or [Community](https://community.mojeek.com/).
+**How do I submit without a Github account?**  
 
-**What is Site Clustering and how does it affect Focus?**
+Github and other similar developer platforms can be very useful for this kind of collaborative work, but we understand that they are not for everyone. If you've created something you really think would be better of shared with others, please get in contact via the [contact page](https://www.mojeek.com/about/contact) or [Community](https://community.mojeek.com/).
+
+**What is Site Clustering and how does it affect Focus?**  
+
 Site Clustering refers to the grouping of results from the same host in order to create a greater variety of websites in results. In a regular Mojeek web search, hosts are clustered; when using Focus, clustering is off by default. You can modify how much or little clustering happens by changing settings in your Focus Dashboard. 
 
 <img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/result_clustering.png">
@@ -23,6 +27,7 @@ Site Clustering refers to the grouping of results from the same host in order to
 Your Dashboard clustering settings will not be carried across to other users, so please bear this in mind when submitting.
 
 **Can I use Focus like !bangs?**
+
 There is not currently a way to do this through Mojeek, but with both Gecko (Firefox, LibreWolf, Mullvad) and Chromium (Chrome, Brave, Vivaldi) browsers you can add *keywords* for searches, which allow for a key press, or series of key presses, to trigger the use of a specific search engine. You can use this functionality with Focus, and this is how some people have told us they've incorporated Focus engines into their setup. You can also use the *Search bar* option in your [Focus Dashboard](https://www.mojeek.com/focus/dashboard) to have your Focus engines appear on both the homepage and search engine results page in the bar itself. 
 
 <img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/focus_search_bar.png">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/PrivacyDingus/focus-templates/blob/main/assets/focus_header.png">
+<img src="./assets/focus_header.png">
 
 # Mojeek Focus
 
@@ -6,8 +6,8 @@
 
 Want to learn more about Focus? You can visit the [Mojeek Focus](https://www.mojeek.com/focus/) page, [search the web you want](https://blog.mojeek.com/2022/08/mojeek-focus-search-the-web-you-want.html) blog post introducing Focus, or dive right in by heading to your [Focus Dashboard](https://www.mojeek.com/focus/dashboard) to get a better idea of what this functionality is for.
 
-Please read the eligibility guidelines in [CONTRIBUTING.md](https://github.com/PrivacyDingus/focus-templates/blob/main/CONTRIBUTING.md) before raising an Issue or submitting a Pull Request in order to add your Focus. **Not all submissions will make it onto the templates list.** 
+Please read the eligibility guidelines in [CONTRIBUTING.md](./CONTRIBUTING.md) before raising an Issue or submitting a Pull Request in order to add your Focus. **Not all submissions will make it onto the templates list.** 
 
-If you have any further questions about Focus then please check out [FAQ.md](https://github.com/PrivacyDingus/focus-templates/blob/main/FAQ.md), you can also help out by raising an Issue or submitting a PR if there is any useful information you believe is missing from this repository. 
+If you have any further questions about Focus then please check out [FAQ.md](./FAQ.md), you can also help out by raising an Issue or submitting a PR if there is any useful information you believe is missing from this repository. 
 
 If you're looking to collaborate, discuss, or sound out ideas, the best place for this is the [Mojeek Community](https://community.mojeek.com/).


### PR DESCRIPTION
- Corrects a typo
- Amends image and link pathways to be ./path-to-file rather than linking to old repos
- Reformats questions in FAQs