### PR TITLE
Edit Cybersecurity Focus (svg and i=), Fixes #36

### DIFF
--- a/focus/cybersecurity.focus
+++ b/focus/cybersecurity.focus
@@ -1,12 +1,12 @@
 # title: Cybersecutiry
 # description: Cybersecurity search
 # author: Jef Roelandt
-# icon: security
+# icon: cybersecurity
 
 i=cybernews.com
 i=thehackernews.com
 i=csoonline.com
 i=securitygladiators.com
-i=cve.mitre.org
+i=cve.org
 i=nvd.nist.gov
 i=cvedetails.com


### PR DESCRIPTION
PR related to #36 
- changes one i= due to site moving
- amends the icon name to match with submitted svg

---

### Checklist

[X] - I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
[X] - I have checked this Focus is not a duplicate (not applicable if amending a template)
[X] - I have checked my svg's license and linked to the svg (not applicable if amending or if no image is supplied)
