### PR TITLE
Add Audio Forums Focus

### DIFF
--- a/focus/audioforums.focus
+++ b/focus/audioforums.focus
@@ -1,0 +1,27 @@
+# title: Audio Forums
+# description: Active Sound Forums
+# author: PrivacyDingus
+# icon: audio
+
+i=.head-fi.org
+i=forum.audiogon.com
+i=.diyaudio.com
+i=.groupdiy.com
+i=.tdpri.com
+i=.sevenstring.org
+i=.talkbass.com
+i=.squier-talk.com
+i=.dogsonacid.com
+i=.guitars101.com
+i=.ultimate-guitar.com
+i=.kvraudio.com
+i=.gearspace.com
+i=.drumforum.org
+i=.mandolincafe.com
+i=forum.pedalpcb.com
+i=.banjohangout.org
+i=.vi-control.net
+i=.llllllll.co
+i=.tascamforums.com
+i=.modwiggler.com
+i=forum.pianoworld.com

--- a/icons/audio.svg
+++ b/icons/audio.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><defs><style>.a{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path class="a" d="M3.5,25.018h9.8767l2.2775-10.9731,2.2775,20.1622L20.2092,9.0623l2.2775,29.8754L24.7642,9.1925,27.0417,36.428l2.2775-25.4062L31.5967,29.778l2.2775-16.2172,2.2775,11.3627H44.5"/></svg>


### PR DESCRIPTION
*Pull Request to add a Focus which searches across a range of different Audio-related forums; some which are about specific instruments such as guitars or synthesizers; some which are about recording techniques i.e. microphone placement; and some which are about vinyl and other music esoterica*

---

### Checklist

[x] - I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
[x] - I have checked this Focus is not a duplicate (not applicable if amending a template)
[x] - I have checked my svg's license and linked to the svg (not applicable if amending or if no image is supplied)
